### PR TITLE
Preserve return value of wrapped methods

### DIFF
--- a/customEvents.js
+++ b/customEvents.js
@@ -127,8 +127,8 @@
                 elementPoint,
                 op;
 
-                //call default actions
-                proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+                //call default actions and preserve return value
+                var ret = proceed.apply(this, Array.prototype.slice.call(arguments, 1));
 
                 //switch on object
                 switch (proto) {
@@ -185,6 +185,8 @@
 
                     customEvent.add(element, events, this);
                 }
+
+                return ret;
             });
         };
 


### PR DESCRIPTION
Highcharts relies on chaining some of these wrapped methods so we must preserve their return values.

For example, without thisHighcharts loses track of plot lines and plot bands making it impossible to remove them later. I added this code to the bottom of the script on the demo page:

```
setTimeout(function() {
  console.log(Highcharts.charts[0].yAxis[0].plotLinesAndBands.length);
  console.log(Highcharts.charts[0].yAxis[1].plotLinesAndBands.length);
}, 500);
```

Before the change see:

> 0
> 0

After the change we see:

> 2
> 0
