### PR TITLE
Main of package.json points to the customEvents.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "highcharts-custom-events",
   "version": "1.4.2",
   "description": "Plugin that allows add extra events, like double / right click on each chart element, for Highcharts.",
-  "main": "customEvents.js",
+  "main": "js/customEvents.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blacklabel/custom_events.git"


### PR DESCRIPTION
I am using Webpack and npm 2.14.4. I would like to bring in highcharts-custom-events by listing it as a dependency in `package.json` of my project, doing npm install (and npm will fetch it and place it in node_modules of my project) and then in a file doing `require('highcharts-custom-events'(Highcharts);`

Without the fix I got this error:
ERROR in ./src/show/HeatmapCanvas.jsx
Module not found: Error: Cannot resolve module 'highcharts-custom-events' in /Users/wbazant/dev/atlas/web/src/main/javascript/expression-atlas-heatmap-highcharts/src/show
 @ ./src/show/HeatmapCanvas.jsx 9:0-35

After the fix, webpack works correctly.
