### PR TITLE
Add support for point events on a heatmap

### DIFF
--- a/js/customEvents.js
+++ b/js/customEvents.js
@@ -140,6 +140,7 @@
 				[HC.PlotLineOrBand, ['render']],
 				[HC.Series, ['drawPoints', 'drawDataLabels']],
 				[seriesTypes.column, ['drawPoints', 'drawDataLabels']],
+				[seriesTypes.heatmap, ['drawPoints', 'drawDataLabels']],
 				[seriesTypes.bar, ['drawPoints', 'drawDataLabels']],
 				[seriesTypes.pie, ['drawPoints', 'drawDataLabels']],
 				[seriesTypes.bubble, ['drawPoints', 'drawDataLabels']],


### PR DESCRIPTION
 They don't work currently- the highcharts' native point events get blocked over here:
```
// reset default events on series and series point
options.events = false;
options.point = {
	events: false
};
```

but the prototype methods of a heatmap aren't listed and the plugin doesn't have an occasion to attach custom events to the points.  Adding `[seriesTypes.heatmap, ['drawPoints']]` fixed it.

drawDataLabels doesn't seem present as a prototype method but I'm adding it for consistency.