### PR TITLE
Fixes issue with trying to access tick.label when using Sankey chart

### DIFF
--- a/js/customEvents.js
+++ b/js/customEvents.js
@@ -182,12 +182,12 @@ function ObjectEventsPlugin(H) {
                     bindElementEvents(axis.axisTitle, (_a = axis.options.title) === null || _a === void 0 ? void 0 : _a.events, chart._customEventsBound);
                 }
                 // Axis Labels
-                if (axis.ticks) {
+                if (axis.ticks && axis.tickPositions) {
                     const tickPositions = axis.tickPositions;
                     tickPositions.forEach(pos => {
                         var _a, _b;
                         const tick = axis.ticks[pos];
-                        if ((_a = tick.label) === null || _a === void 0 ? void 0 : _a.element) {
+                        if (tick && ((_a = tick.label) === null || _a === void 0 ? void 0 : _a.element)) {
                             const customAxisLabelObject = {
                                 element: tick.label,
                                 axis: axis,

--- a/ts/customEvents.ts
+++ b/ts/customEvents.ts
@@ -224,12 +224,12 @@ export default function ObjectEventsPlugin(H: typeof Highcharts) {
 				}
 
 				// Axis Labels
-				if (axis.ticks) {
+         		if (axis.ticks && axis.tickPositions) {
 					const tickPositions = axis.tickPositions;
 
 					tickPositions.forEach(pos => {
 						const tick = axis.ticks[pos];
-						if (tick.label?.element) {
+						if (tick && tick.label?.element) {
 							const customAxisLabelObject: customAxisLabel = {
 								element: tick.label,
 								axis: axis,


### PR DESCRIPTION
**Fix: Add null checks for Sankey chart compatibility**

Problem:
The plugin crashes when rendering Sankey charts with the following error:
`TypeError: Cannot read properties of undefined (reading 'label')`

**Root Cause:**
In the `bindChartEvents` function, the code assumes all chart axes have `tickPositions` and that `axis.ticks[pos]` will always return a valid tick object. However, Sankey charts don't use traditional axes with ticks, causing: 

- axis.tickPositions to be `undefined`
- axis.ticks[pos] to return `undefined` for certain positions 

**Solution:**
Added null/undefined checks before accessing tick properties:

```
// Before
if (axis.ticks) {
    const tickPositions = axis.tickPositions;
    tickPositions.forEach(pos => {
        const tick = axis.ticks[pos];
        if (tick.label?.element) { // ❌ Crashes if tick is undefined

// After
if (axis.ticks && axis.tickPositions) {
    const tickPositions = axis.tickPositions;
    tickPositions.forEach(pos => {
        const tick = axis.ticks[pos];
        if (tick && tick.label?.element) { // ✅ Safe
```

Demo where issue is visible in browser console:
https://jsfiddle.net/241fkqr6/

**Impact:**
This fix ensures the plugin works correctly with Sankey charts and other chart types that don't have traditional axes, while maintaining backward compatibility with all existing chart types.
